### PR TITLE
Update 0 0 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## v0_2_0 - 2024-09-24
+
+### Fixed
+
+- Converted Indexes to use BTree to force deterministic ordering.  Lookup occurs in index for every query with a prev argument. The query selects the next minimum payment or subscription by ID if the specified item has been deleted
+- The label for the productId field has been fixed for the 79subCreate block.
+
+### Updates
+
+- productId, account, targetAccount, and service added to the Service.Product type as a convenience field as it reduces a call to get subscription to retrieve those values.

--- a/icrc-79.md
+++ b/icrc-79.md
@@ -252,6 +252,10 @@ type PaymentRecord = record {
     ledgerTransactionId: nat;
     transactionId: nat;
     feeTransactionId: opt nat;
+    targetAccount: opt nat;
+    account: Account;
+    productId: ?Nat;
+    service: Principal;
     subscriptionId: nat;
     result: Bool;
 };

--- a/pic/subs/subs.test.ts
+++ b/pic/subs/subs.test.ts
@@ -406,6 +406,12 @@ describe("test subs", () => {
 
     const item = serviceSubs7[0].subscriptionId;
 
+    const serviceSubsAll= await subs_fixture.actor.icrc79_get_service_subscriptions(serviceProvider2.getPrincipal(), [], [], []);
+
+    console.log("serviceSubsAll", serviceSubsAll);
+
+
+
     const serviceSubs8= await subs_fixture.actor.icrc79_get_service_subscriptions(serviceProvider2.getPrincipal(), [], [item], [1n]);
 
     console.log("serviceSubs8", serviceSubs8);
@@ -638,12 +644,23 @@ describe("test subs", () => {
 
     console.log("payments8", payments8);
 
+    const paymentsServiceAll = await subs_fixture.actor.icrc79_get_service_payments(serviceProvider2.getPrincipal(), [{
+      subscriptions: [],
+      status: [],
+      products: [[[2n]]],
+    }], [],  []);
+
+    console.log("paymentsServiceAll", paymentsServiceAll);
+
 
     const paymentsService9 = await subs_fixture.actor.icrc79_get_service_payments(serviceProvider2.getPrincipal(), [{
       subscriptions: [],
       status: [],
       products: [[[2n]]],
     }], [],  [2n]);
+
+
+    console.log("paymentsService9", paymentsService9);
 
     expect(paymentsService9.length).toEqual(2);
 
@@ -654,6 +671,8 @@ describe("test subs", () => {
       status: [],
       products: [[[2n]]],
     }], [item3],  [2n]);
+
+    console.log("paymentsService10", paymentsService10);
 
     expect(paymentsService10.length).toEqual(2);
 

--- a/src/Service.mo
+++ b/src/Service.mo
@@ -239,6 +239,28 @@ module {
     #Err: PauseError;
   };
 
+
+  public type PaymentRecordv0_1_0 = {
+    paymentId: Nat;
+    date: Nat; // Timestamp of the payment
+    amount: Nat;
+    fee: ?Nat;
+    rate: ?ExchangeRate; // if used
+    ledgerTransactionId: ?Nat;
+    transactionId: ?Nat;
+    feeTransactionId: ?Nat;
+    brokerTransactionId: ?Nat;
+    brokerFee: ?Nat;
+    subscriptionId: Nat;
+    result: {
+      #Ok;
+      #Err: {
+        code: Nat;
+        message: Text;
+      };
+    };
+  };
+
   public type PaymentRecord = {
     paymentId: Nat;
     date: Nat; // Timestamp of the payment
@@ -250,6 +272,10 @@ module {
     feeTransactionId: ?Nat;
     brokerTransactionId: ?Nat;
     brokerFee: ?Nat;
+    account: Account;
+    targetAccount: ?Account;
+    productId: ?Nat;
+    service: Principal;
     subscriptionId: Nat;
     result: {
       #Ok;
@@ -332,13 +358,16 @@ module {
     icrc79_confirm_subscription : (confirmRequests: [ConfirmRequests]) -> async [ConfirmResult];
     icrc79_pause_subscription : (req: PauseRequest) -> async [PauseResult];
 
+   
 
     icrc79_get_user_subscriptions : query (filter: ?UserSubscriptionsFilter, prev: ?Nat, take: ?Nat) -> async [Subscription];
     icrc79_get_service_subscriptions : query (service: Principal, filter: ?ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) -> async [Subscription];
     icrc79_get_user_payments : query (filter: ?UserSubscriptionsFilter, prev: ?Nat, take: ?Nat) -> async [PaymentRecord];
-    icrc79_get_payments_pending : query (subscriptionIds: [Nat]) -> async [?PendingPayment];
     icrc79_get_service_payments : query (service: Principal, filter: ?ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) -> async [PaymentRecord];
-  
+
+
+    icrc79_get_payments_pending : query (subscriptionIds: [Nat]) -> async [?PendingPayment];
+    
     icrc79_get_service_notifications : query (service: Principal, prev: ?Nat, take: ?Nat) -> async [ServiceNotification];
     icrc79_metadata : query () -> async [(Text, Value)];
     icrc79_max_query_batch_size : query () -> async Nat;

--- a/src/canisters/main.mo
+++ b/src/canisters/main.mo
@@ -2,6 +2,8 @@ import D "mo:base/Debug";
 import Blob "mo:base/Blob";
 import Text "mo:base/Text";
 import Principal "mo:base/Principal";
+import Nat "mo:base/Nat";
+
 
 
 import Service "../Service";
@@ -162,7 +164,7 @@ shared (deployer) actor class Subs(initArgs: ?{
 
     public query func icrc79_get_service_subscriptions(service: Principal, filter: ?Service.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : async [Service.Subscription] {
         // Implementation of get service subscriptions logic
-        let result = q_icrc79().get_sevice_subscriptions(service, filter, prev, take);
+        let result = q_icrc79().get_service_subscriptions(service, filter, prev, take);
         result;
     };
 
@@ -172,19 +174,17 @@ shared (deployer) actor class Subs(initArgs: ?{
         q_icrc79().get_user_payments(msg.caller, filter, prev, take);
     };
 
+    public query func icrc79_get_service_payments(service: Principal, filter:?ICRC79.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : async [Service.PaymentRecord] {
+        // Implementation of get service payments logic
+         let result = q_icrc79().get_service_payments(service, filter, prev, take);
+        result;
+    };
+
     public query(msg) func icrc79_get_payments_pending(subscriptionIds: [Nat]) : async [?Service.PendingPayment] {
         // Implementation of get user pending payments logic
         debug if(debug_channel.announce) D.print("Subs:     public query func icrc79_payments_pending(subscriptionIds: [Nat]) : async [Service.PendingPayment] {" # debug_show(subscriptionIds));
         q_icrc79().get_payments_pending(msg.caller, subscriptionIds);
     };
-
-    public query func icrc79_get_service_payments(service: Principal, filter:?ICRC79.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : async [Service.PaymentRecord] {
-        // Implementation of get service payments logic
-         let result = q_icrc79().get_sevice_payments(service, filter, prev, take);
-        result;
-    };
-
-
 
     public query(msg) func icrc79_get_service_notifications(service: Principal, prev: ?Nat, take: ?Nat) : async [Service.ServiceNotification] {
         // Implementation of get service notifications logic

--- a/src/declarations/subs/subs.did
+++ b/src/declarations/subs/subs.did
@@ -42,11 +42,10 @@ type TokenInfo =
 type Time = nat;
 type SubscriptionStateShared = 
  record {
-   ICRC17Endpoint: opt principal;
    account: Account;
    amountPerInterval: nat;
    baseRateAsset: opt Asset;
-   brokerId: opt principal;
+   brokerId: opt Account;
    checkRate: opt CheckRate;
    endDate: opt nat;
    history: vec nat;
@@ -80,7 +79,7 @@ type SubscriptionRequestItem =
                     Asset__1;
                     CheckRate__1;
                   };
-   broker: principal;
+   broker: Account__1;
    createdAtTime: nat;
    endDate: nat;
    firstPayment: nat;
@@ -100,6 +99,7 @@ type SubscriptionError =
    Duplicate;
    FoundActiveSubscription: nat;
    InsufficientAllowance: nat;
+   InsufficientBalance: nat;
    InvalidDate;
    InvalidInterval;
    Other: record {
@@ -115,7 +115,7 @@ type Subscription =
    account: Account__1;
    amountPerInterval: nat;
    baseRateAsset: opt Asset__1;
-   brokerId: opt principal;
+   brokerId: opt Account__1;
    endDate: opt nat;
    interval: Interval__1;
    productId: opt nat;
@@ -274,6 +274,7 @@ type PendingPayment =
  };
 type PaymentRecord = 
  record {
+   account: Account__1;
    amount: nat;
    brokerFee: opt nat;
    brokerTransactionId: opt nat;
@@ -282,6 +283,7 @@ type PaymentRecord =
    feeTransactionId: opt nat;
    ledgerTransactionId: opt nat;
    paymentId: nat;
+   productId: opt nat;
    rate: opt ExchangeRate;
    result: variant {
              Err: record {
@@ -290,7 +292,9 @@ type PaymentRecord =
                   };
              Ok;
            };
+   "service": principal;
    subscriptionId: nat;
+   targetAccount: opt Account__1;
    transactionId: opt nat;
  };
 type PauseResult = 
@@ -429,6 +433,7 @@ type CancelResult =
      };
 type CancelError = 
  variant {
+   InvalidStatus: SubStatus__1;
    NotFound;
    Other: record {
             code: nat;

--- a/src/declarations/subs/subs.did.d.ts
+++ b/src/declarations/subs/subs.did.d.ts
@@ -37,7 +37,8 @@ export type AssetClass = { 'Cryptocurrency' : null } |
 export type AssetClass__1 = { 'Cryptocurrency' : null } |
   { 'FiatCurrency' : null };
 export interface Asset__1 { 'class' : AssetClass__1, 'symbol' : string }
-export type CancelError = { 'NotFound' : null } |
+export type CancelError = { 'InvalidStatus' : SubStatus__1 } |
+  { 'NotFound' : null } |
   { 'Unauthorized' : null } |
   { 'Other' : { 'code' : bigint, 'message' : string } };
 export type CancelResult = [] | [{ 'Ok' : bigint } | { 'Err' : CancelError }];
@@ -132,16 +133,20 @@ export interface PauseRequestItem {
 export type PauseResult = [] | [{ 'Ok' : bigint } | { 'Err' : PauseError }];
 export interface PaymentRecord {
   'fee' : [] | [bigint],
+  'service' : Principal,
   'result' : { 'Ok' : null } |
     { 'Err' : { 'code' : bigint, 'message' : string } },
   'feeTransactionId' : [] | [bigint],
   'date' : bigint,
   'rate' : [] | [ExchangeRate],
+  'productId' : [] | [bigint],
   'ledgerTransactionId' : [] | [bigint],
   'subscriptionId' : bigint,
   'brokerFee' : [] | [bigint],
+  'account' : Account__1,
   'paymentId' : bigint,
   'amount' : bigint,
+  'targetAccount' : [] | [Account__1],
   'brokerTransactionId' : [] | [bigint],
   'transactionId' : [] | [bigint],
 }
@@ -282,7 +287,7 @@ export interface Subscription {
   'subscriptionId' : bigint,
   'baseRateAsset' : [] | [Asset__1],
   'account' : Account__1,
-  'brokerId' : [] | [Principal],
+  'brokerId' : [] | [Account__1],
   'amountPerInterval' : bigint,
   'targetAccount' : [] | [Account__1],
   'tokenCanister' : Principal,
@@ -293,6 +298,7 @@ export type SubscriptionError = { 'TokenNotFound' : null } |
   { 'SubscriptionNotFound' : null } |
   { 'Duplicate' : null } |
   { 'FoundActiveSubscription' : bigint } |
+  { 'InsufficientBalance' : bigint } |
   { 'InvalidDate' : null } |
   { 'Unauthorized' : null } |
   { 'Other' : { 'code' : bigint, 'message' : string } } |
@@ -300,7 +306,7 @@ export type SubscriptionError = { 'TokenNotFound' : null } |
 export type SubscriptionRequest = Array<Array<SubscriptionRequestItem>>;
 export type SubscriptionRequestItem = { 'serviceCanister' : Principal } |
   { 'firstPayment' : bigint } |
-  { 'broker' : Principal } |
+  { 'broker' : Account__1 } |
   { 'endDate' : bigint } |
   { 'interval' : Interval__1 } |
   { 'memo' : Uint8Array | number[] } |
@@ -334,9 +340,8 @@ export interface SubscriptionStateShared {
   'baseRateAsset' : [] | [Asset],
   'checkRate' : [] | [CheckRate],
   'account' : Account,
-  'brokerId' : [] | [Principal],
+  'brokerId' : [] | [Account],
   'nextTimerId' : [] | [ActionId],
-  'ICRC17Endpoint' : [] | [Principal],
   'nextPayment' : [] | [bigint],
   'amountPerInterval' : bigint,
   'targetAccount' : [] | [Account],

--- a/src/declarations/subs/subs.did.js
+++ b/src/declarations/subs/subs.did.js
@@ -41,9 +41,8 @@ export const idlFactory = ({ IDL }) => {
     'baseRateAsset' : IDL.Opt(Asset),
     'checkRate' : IDL.Opt(CheckRate),
     'account' : Account,
-    'brokerId' : IDL.Opt(IDL.Principal),
+    'brokerId' : IDL.Opt(Account),
     'nextTimerId' : IDL.Opt(ActionId),
-    'ICRC17Endpoint' : IDL.Opt(IDL.Principal),
     'nextPayment' : IDL.Opt(IDL.Nat),
     'amountPerInterval' : IDL.Nat,
     'targetAccount' : IDL.Opt(Account),
@@ -111,7 +110,14 @@ export const idlFactory = ({ IDL }) => {
     'tokenCanister' : IDL.Principal,
     'tokenPointer' : IDL.Opt(IDL.Nat),
   });
+  const SubStatus__1 = IDL.Variant({
+    'Paused' : IDL.Tuple(IDL.Nat, IDL.Principal, IDL.Text),
+    'Active' : IDL.Null,
+    'WillCancel' : IDL.Tuple(IDL.Nat, IDL.Principal, IDL.Text),
+    'Canceled' : IDL.Tuple(IDL.Nat, IDL.Nat, IDL.Principal, IDL.Text),
+  });
   const CancelError = IDL.Variant({
+    'InvalidStatus' : SubStatus__1,
     'NotFound' : IDL.Null,
     'Unauthorized' : IDL.Null,
     'Other' : IDL.Record({ 'code' : IDL.Nat, 'message' : IDL.Text }),
@@ -133,6 +139,7 @@ export const idlFactory = ({ IDL }) => {
     'SubscriptionNotFound' : IDL.Null,
     'Duplicate' : IDL.Null,
     'FoundActiveSubscription' : IDL.Nat,
+    'InsufficientBalance' : IDL.Nat,
     'InvalidDate' : IDL.Null,
     'Unauthorized' : IDL.Null,
     'Other' : IDL.Record({ 'code' : IDL.Nat, 'message' : IDL.Text }),
@@ -141,12 +148,6 @@ export const idlFactory = ({ IDL }) => {
   const ConfirmResult = IDL.Opt(
     IDL.Variant({ 'Ok' : IDL.Nat, 'Err' : SubscriptionError })
   );
-  const SubStatus__1 = IDL.Variant({
-    'Paused' : IDL.Tuple(IDL.Nat, IDL.Principal, IDL.Text),
-    'Active' : IDL.Null,
-    'WillCancel' : IDL.Tuple(IDL.Nat, IDL.Principal, IDL.Text),
-    'Canceled' : IDL.Tuple(IDL.Nat, IDL.Nat, IDL.Principal, IDL.Text),
-  });
   const Interval__1 = IDL.Variant({
     'Hourly' : IDL.Null,
     'Interval' : IDL.Nat,
@@ -176,7 +177,7 @@ export const idlFactory = ({ IDL }) => {
     'subscriptionId' : IDL.Nat,
     'baseRateAsset' : IDL.Opt(Asset__1),
     'account' : Account__1,
-    'brokerId' : IDL.Opt(IDL.Principal),
+    'brokerId' : IDL.Opt(Account__1),
     'amountPerInterval' : IDL.Nat,
     'targetAccount' : IDL.Opt(Account__1),
     'tokenCanister' : IDL.Principal,
@@ -271,6 +272,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const PaymentRecord = IDL.Record({
     'fee' : IDL.Opt(IDL.Nat),
+    'service' : IDL.Principal,
     'result' : IDL.Variant({
       'Ok' : IDL.Null,
       'Err' : IDL.Record({ 'code' : IDL.Nat, 'message' : IDL.Text }),
@@ -278,11 +280,14 @@ export const idlFactory = ({ IDL }) => {
     'feeTransactionId' : IDL.Opt(IDL.Nat),
     'date' : IDL.Nat,
     'rate' : IDL.Opt(ExchangeRate),
+    'productId' : IDL.Opt(IDL.Nat),
     'ledgerTransactionId' : IDL.Opt(IDL.Nat),
     'subscriptionId' : IDL.Nat,
     'brokerFee' : IDL.Opt(IDL.Nat),
+    'account' : Account__1,
     'paymentId' : IDL.Nat,
     'amount' : IDL.Nat,
+    'targetAccount' : IDL.Opt(Account__1),
     'brokerTransactionId' : IDL.Opt(IDL.Nat),
     'transactionId' : IDL.Opt(IDL.Nat),
   });
@@ -327,7 +332,7 @@ export const idlFactory = ({ IDL }) => {
   const SubscriptionRequestItem = IDL.Variant({
     'serviceCanister' : IDL.Principal,
     'firstPayment' : IDL.Nat,
-    'broker' : IDL.Principal,
+    'broker' : Account__1,
     'endDate' : IDL.Nat,
     'interval' : Interval__1,
     'memo' : IDL.Vec(IDL.Nat8),
@@ -478,9 +483,8 @@ export const init = ({ IDL }) => {
     'baseRateAsset' : IDL.Opt(Asset),
     'checkRate' : IDL.Opt(CheckRate),
     'account' : Account,
-    'brokerId' : IDL.Opt(IDL.Principal),
+    'brokerId' : IDL.Opt(Account),
     'nextTimerId' : IDL.Opt(ActionId),
-    'ICRC17Endpoint' : IDL.Opt(IDL.Principal),
     'nextPayment' : IDL.Opt(IDL.Nat),
     'amountPerInterval' : IDL.Nat,
     'targetAccount' : IDL.Opt(Account),

--- a/src/declarations/tester/tester.did
+++ b/src/declarations/tester/tester.did
@@ -7,6 +7,7 @@ type SubscriptionError =
    Duplicate;
    FoundActiveSubscription: nat;
    InsufficientAllowance: nat;
+   InsufficientBalance: nat;
    InvalidDate;
    InvalidInterval;
    Other: record {

--- a/src/declarations/tester/tester.did.d.ts
+++ b/src/declarations/tester/tester.did.d.ts
@@ -11,6 +11,7 @@ export type SubscriptionError = { 'TokenNotFound' : null } |
   { 'SubscriptionNotFound' : null } |
   { 'Duplicate' : null } |
   { 'FoundActiveSubscription' : bigint } |
+  { 'InsufficientBalance' : bigint } |
   { 'InvalidDate' : null } |
   { 'Unauthorized' : null } |
   { 'Other' : { 'code' : bigint, 'message' : string } } |

--- a/src/declarations/tester/tester.did.js
+++ b/src/declarations/tester/tester.did.js
@@ -5,6 +5,7 @@ export const idlFactory = ({ IDL }) => {
     'SubscriptionNotFound' : IDL.Null,
     'Duplicate' : IDL.Null,
     'FoundActiveSubscription' : IDL.Nat,
+    'InsufficientBalance' : IDL.Nat,
     'InvalidDate' : IDL.Null,
     'Unauthorized' : IDL.Null,
     'Other' : IDL.Record({ 'code' : IDL.Nat, 'message' : IDL.Text }),

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -47,15 +47,15 @@ module {
   public type TokenInfo =                       MigrationTypes.Current.TokenInfo;
   public type SubStatus =                       MigrationTypes.Current.SubStatus;
   public type Value =                           MigrationTypes.Current.Value;
-  public type ProductSubscriptionMap =          MigrationTypes.Current.ProductSubscriptionMap;
-  public type ServiceSubscriptionMap =          MigrationTypes.Current.ServiceSubscriptionMap;
-  public type SubAccountSubscriptionMap =       MigrationTypes.Current.SubAccountSubscriptionMap;
-  public type UserSubscriptionIndex =           MigrationTypes.Current.UserSubscriptionIndex;
+  public type ProductSubscriptionMap =          MigrationTypes.Current.ProductSubscriptionMap2;
+  public type ServiceSubscriptionMap =          MigrationTypes.Current.ServiceSubscriptionMap2;
+  public type SubAccountSubscriptionMap =       MigrationTypes.Current.SubAccountSubscriptionMap2;
+  public type UserSubscriptionIndex =           MigrationTypes.Current.UserSubscriptionIndex2;
   public type CanAddSubscription =              MigrationTypes.Current.CanAddSubscription;
   public type ScheduledPaymentArgs =            MigrationTypes.Current.ScheduledPaymentArgs;
   public type ServiceNotificationType =         MigrationTypes.Current.ServiceNotificationType;
   public type ServiceNotification =             MigrationTypes.Current.ServiceNotification;
-  public type PaymentRecord =                   MigrationTypes.Current.PaymentRecord;
+  public type PaymentRecord =                   MigrationTypes.Current.PaymentRecord2;
   public type ExchangeRate =                    MigrationTypes.Current.ExchangeRate;
   public type ExchangeRateMetadata =            MigrationTypes.Current.ExchangeRateMetadata;
   public type Asset =                           MigrationTypes.Current.Asset;
@@ -70,6 +70,7 @@ module {
 
   public let ktHash =                           MigrationTypes.Current.ktHash;
   public let nullNHash =                        MigrationTypes.Current.nullNHash;
+  public let nullNcompare =                     MigrationTypes.Current.nullNcompare;
   public let nullSubaccount =                   MigrationTypes.Current.nullSubaccount;
   public let TT =                               MigrationTypes.Current.TimerTool;
   public let isICRC80 =                         MigrationTypes.Current.isICRC80;
@@ -102,7 +103,7 @@ module {
   
 
   public func initialState() : State {#v0_0_0(#data)};
-  public let currentStateVersion = #v0_1_0(#id);
+  public let currentStateVersion = #v0_2_0(#id);
 
   public let init = Migration.migrate;
 
@@ -110,6 +111,15 @@ module {
   public let Map = MigrationTypes.Current.Map;
   public let Set = MigrationTypes.Current.Set;
   public let Vector = MigrationTypes.Current.Vector;
+  public let BTree = MigrationTypes.Current.BTree;
+
+  public let subaccountToBlob = MigrationTypes.Current.subaccountToBlob;
+  public let findOrCreateUserProductMap = MigrationTypes.Current.findOrCreateUserProductMap;
+  public let findOrCreateServiceProductMap = MigrationTypes.Current.findOrCreateServiceProductMap;
+  public let servicePaymentRecordCompare = MigrationTypes.Current.servicePaymentRecordCompare;
+  public let serviceSubscriptionCompare = MigrationTypes.Current.serviceSubscriptionCompare;
+  public let userSubscriptionCompare = MigrationTypes.Current.userSubscriptionCompare;
+  public let userPaymentRecordCompare = MigrationTypes.Current.userPaymentRecordCompare;
 
   public let ONE_MINUTE = 60_000_000_000;
 
@@ -117,11 +127,11 @@ module {
 
     var state : CurrentState = switch(stored){
       case(null) {
-        let #v0_1_0(#data(foundState)) = init(initialState(),currentStateVersion, null, canister);
+        let #v0_2_0(#data(foundState)) = init(initialState(),currentStateVersion, null, canister);
         foundState;
       };
       case(?val) {
-        let #v0_1_0(#data(foundState)) = init(val,currentStateVersion, null, canister);
+        let #v0_2_0(#data(foundState)) = init(val,currentStateVersion, null, canister);
         foundState;
       };
     };
@@ -435,7 +445,7 @@ module {
 
       label proc for(thisSub in confirmRequests.vals()){
 
-        let ?subscription = Map.get(state.subscriptions, Map.nhash, thisSub.subscriptionId) else {
+        let ?subscription = BTree.get(state.subscriptions2, Nat.compare, thisSub.subscriptionId) else {
           results.add(?#Err(#SubscriptionNotFound));
           xnet += 3_000_000;
           continue proc;
@@ -564,21 +574,21 @@ module {
 
       //check
         let existingSubscriptions = do? {
-          let subAccountMap = Map.get(state.userSubscriptionIndex, Map.phash, parsedRequest.account.owner);
+          let subAccountMap = BTree.get(state.userSubscriptionIndex2, Principal.compare, parsedRequest.account.owner);
           let subBlob = subaccountToBlob(parsedRequest.account.subaccount);
-          let serviceMap = Map.get(subAccountMap!, Map.bhash, subBlob);
-          let productSubMap = Map.get(serviceMap!, Map.phash, parsedRequest.serviceCanister);
-          let productMap = Map.get(productSubMap!, nullNHash, parsedRequest.productId);
+          let serviceMap = BTree.get(subAccountMap!, Blob.compare, subBlob);
+          let productSubMap = BTree.get(serviceMap!, Principal.compare, parsedRequest.serviceCanister);
+          let productMap = BTree.get(productSubMap!, nullNcompare, parsedRequest.productId);
           productMap!;
         };
 
         switch(existingSubscriptions){
           case(null) {};
           case(?val){
-            label search for(thisSub in Set.keys(val)){
-              let ?thisSubDetail = Map.get(state.subscriptions, Map.nhash, thisSub) else continue search;
+            label search for(thisSub in BTree.entries(val)){
+              let ?thisSubDetail = BTree.get(state.subscriptions2, Nat.compare, thisSub.0) else continue search;
               if(thisSubDetail.status == #Active){
-                results.add(?#Err(#FoundActiveSubscription(thisSub)));
+                results.add(?#Err(#FoundActiveSubscription(thisSub.0)));
                 continue proc;
               };
             };
@@ -787,7 +797,7 @@ module {
         let reason = thisItem.reason;
 
         // get the subscription
-        let ?subscription = Map.get(state.subscriptions, Map.nhash, subscriptionId: Nat) else {
+        let ?subscription = BTree.get(state.subscriptions2, Nat.compare, subscriptionId: Nat) else {
           results.add(?#Err(#NotFound));
           continue proc;
         };
@@ -839,7 +849,7 @@ module {
         let active = thisItem.active;
 
         // get the subscription
-        let ?subscription = Map.get(state.subscriptions, Map.nhash, subscriptionId: Nat) else {
+        let ?subscription = BTree.get(state.subscriptions2, Nat.compare, subscriptionId: Nat) else {
           results.add(?#Err(#NotFound));
           continue proc;
         };
@@ -909,101 +919,19 @@ module {
       return Buffer.toArray(results);
     };
 
-    public func subaccountToBlob(aBlob : ?Blob) : Blob {
-      switch(aBlob){
-        case(null) nullSubaccount;
-        case(?val) val;
-      };
-    };
-
-    private func findOrCreateUserProductMap(subscription: SubscriptionState) : Set.Set<Nat> {
-
-      debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap" # debug_show(subscription));
-      
-      let accountMap : SubAccountSubscriptionMap = switch(Map.get(state.userSubscriptionIndex, Map.phash, subscription.account.owner)){
-        case(null) {
-
-          debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap accountMap null" # debug_show(subscription.account.owner));
-          let accountMap = Map.new<Blob, ServiceSubscriptionMap>();
-          ignore Map.put<Principal,SubAccountSubscriptionMap>(state.userSubscriptionIndex, Map.phash, subscription.account.owner, accountMap);
-          accountMap;
-        };
-        case(?val) val;
-      };
-
-      let subBlob = subaccountToBlob(subscription.account.subaccount);
-
-      let serviceMap : ServiceSubscriptionMap = switch(Map.get(accountMap, Map.bhash, subBlob)){
-        case(null) {
-          debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap serviceMap null" # debug_show(subscription.account.subaccount));
-          let serviceMap = Map.new<Principal, ProductSubscriptionMap>();
-          ignore Map.put<Blob, ServiceSubscriptionMap>(accountMap, Map.bhash, subBlob, serviceMap);
-          serviceMap;
-        };
-        case(?val) val;
-      };
-
-      let productSubMap = switch(Map.get(serviceMap, Map.phash, subscription.serviceCanister)){
-        case(null) {
-          debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap productMap null" # debug_show(subscription.serviceCanister));
-          let productSubMap = Map.new<?Nat, Set.Set<Nat>>();
-          ignore Map.put(serviceMap, Map.phash, subscription.serviceCanister, productSubMap);
-          productSubMap;
-        };
-        case(?val) val;
-      };
-
-      let productMap = switch(Map.get(productSubMap, nullNHash, subscription.productId)){
-        case(null) {
-          debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap productMap null" # debug_show(subscription.productId));
-          let productMap = Set.new<Nat>();
-          ignore Map.put(productSubMap, nullNHash, subscription.productId, productMap);
-          productMap;
-        };
-        case(?val) val;
-      };
-
-      productMap;
-    };
-
-    private func findOrCreateServiceProductMap(subscription: SubscriptionState) : Set.Set<Nat> {
-
-      debug logDebug(debug_channel.subscribe, "Subs: findOrCreateServiceProductMap" # debug_show(subscription));
-      let productSubMap = switch(Map.get(state.serviceSubscriptionIndex, Map.phash, subscription.serviceCanister)){
-        case(null) {
-          debug logDebug(debug_channel.subscribe, "Subs: findOrCreateServiceProductMap productMap null" # debug_show(subscription.serviceCanister));
-          let productSubMap = Map.new<?Nat, Set.Set<Nat>>();
-          ignore Map.put(state.serviceSubscriptionIndex, Map.phash, subscription.serviceCanister, productSubMap);
-          productSubMap;
-        };
-        case(?val) val;
-      };
-
-      let productMap = switch(Map.get(productSubMap, nullNHash, subscription.productId)){
-        case(null) {
-          debug logDebug(debug_channel.subscribe, "Subs: findOrCreateServiceProductMap productMap null" # debug_show(subscription.productId));
-          let productMap = Set.new<Nat>();
-          ignore Map.put(productSubMap, nullNHash, subscription.productId, productMap);
-          productMap;
-        };
-        case(?val) val;
-      };
-      productMap;
-    };
-
     private func fileSubscription(subscription: SubscriptionState) : () {
 
       // Add the subscription to the userIndex
       
-      let userProductMap = findOrCreateUserProductMap(subscription);
-      let serviceProductMap = findOrCreateServiceProductMap(subscription);
+      let userProductMap = findOrCreateUserProductMap(state, subscription);
+      let serviceProductMap = findOrCreateServiceProductMap(state, subscription);
 
-      ignore Set.put(userProductMap, Set.nhash, subscription.subscriptionId);
+      ignore BTree.insert(userProductMap, Nat.compare, subscription.subscriptionId, true);
 
-      ignore Set.put(serviceProductMap, Set.nhash, subscription.subscriptionId);
+      ignore BTree.insert(serviceProductMap, Nat.compare, subscription.subscriptionId, true);
 
       // Add the subscription to the globalmap
-      ignore Map.put(state.subscriptions, Map.nhash, subscription.subscriptionId, subscription);
+      ignore BTree.insert(state.subscriptions2, Nat.compare, subscription.subscriptionId, subscription);
     };
 
     private func willCancelSubscription<system>(caller: Principal, reason: Text, subscription: SubscriptionState) : () {
@@ -1235,7 +1163,7 @@ module {
     
 
     // 2. Retrieve the subscription from the global state
-    let ?subscription = Map.get(state.subscriptions, Map.nhash, subscriptionDetails.subscriptionId) else {
+    let ?subscription = BTree.get(state.subscriptions2, Nat.compare, subscriptionDetails.subscriptionId) else {
         debug logDebug(debug_channel.announce, "Subs: subscriptionPayment subscription not found" # debug_show(subscriptionDetails.subscriptionId));
         return #err(#trappable({error_code = 2; message = "Subscription Not Found";}));
     };
@@ -1404,6 +1332,10 @@ module {
             var transactionId = ?transactionId;
             subscriptionId = subscription.subscriptionId;
             amount = total;
+            account = subscription.account;
+            targetAccount = subscription.targetAccount;
+            service = subscription.serviceCanister;
+            productId = subscription.productId;
             rate = rateUsed;
             var ledgerTransactionId = ?transactionId;
             subscription = subscription.subscriptionId;
@@ -1416,7 +1348,7 @@ module {
           debug logDebug(debug_channel.announce, "Subs: subscriptionPayment newPaymentRecord" # debug_show(newPayment));
 
           Vector.add(subscription.history, paymentId);
-          ignore Map.put(state.payments, Map.nhash, paymentId, newPayment);
+          ignore BTree.insert(state.payments2, Nat.compare, paymentId, newPayment);
           subscription.nextPaymentAmount := null; // Clear the next payment amount
 
           // 7. Schedule the next payment if not past the end date
@@ -1645,6 +1577,25 @@ module {
     };
   };
 
+  private let minPayment = {
+      account = {owner = Principal.fromText("aaaaaa-aa"); subaccount = null};
+      amount = 0;
+      date = 0;
+      fee = ?0;
+      paymentId = 0;
+      brokerFee = ?0;
+      brokerTransactionId = ?0;
+      rate = null;
+      subscriptionId = 0;
+      result = #Ok;
+      service = Principal.fromText("aaaaaa-aa");
+      productId = null;
+      transactionId = ?0;
+      ledgerTransactionId = ?0;
+      feeTransactionId = ?0;
+      targetAccount = null;
+    };
+
   //MARK: Queries
   public func get_user_payments(caller: Principal, filter: ?UserSubscriptionsFilter, prev: ?Nat, take: ?Nat) : [Service.PaymentRecord] {
     // Implementation of get user payments logic
@@ -1655,31 +1606,83 @@ module {
       case(?val) false;
     };
 
-    let target = switch(prev){
-      case(null) 0;
-      case(?val) val;
+    let target : Service.PaymentRecord = switch(prev){
+      case(null) minPayment;
+      case(?val){
+    
+        switch( BTree.get<Nat, PaymentRecord>(state.payments2, Nat.compare, val)){
+          case(null){ 
+            //find the closest item if any less than the id...incase it was deleted
+            let items = BTree.scanLimit(state.payments2, Nat.compare, 0, val, #bwd, 1).results;
+            if(items.size() > 0){
+              let val = items[0].1;
+              {
+                paymentId = val.paymentId;
+                date = val.date;
+                amount = val.amount;
+                fee = val.fee;
+                brokerFee = val.brokerFee;
+                brokerTransactionId = val.brokerTransactionId;
+                rate = val.rate;
+                ledgerTransactionId = val.ledgerTransactionId;
+                transactionId = val.transactionId;
+                feeTransactionId = val.feeTransactionId;
+                subscriptionId = val.subscriptionId;
+                productId = val.productId;
+                service = val.service;
+                targetAccount = val.targetAccount;
+                account = val.account;
+                result = val.result;
+              } : Service.PaymentRecord;
+            } else {
+              minPayment;
+            };
+          };
+          case(?val){
+            {
+              paymentId = val.paymentId;
+              date = val.date;
+              amount = val.amount;
+              fee = val.fee;
+              brokerFee = val.brokerFee;
+              brokerTransactionId = val.brokerTransactionId;
+              rate = val.rate;
+              ledgerTransactionId = val.ledgerTransactionId;
+              transactionId = val.transactionId;
+              feeTransactionId = val.feeTransactionId;
+              subscriptionId = val.subscriptionId;
+              productId = val.productId;
+              service = val.service;
+              targetAccount = val.targetAccount;
+              account = val.account;
+              result = val.result;
+            } : Service.PaymentRecord;
+          };
+          
+        };
+      };
     };
 
-    let ?subs = Map.get(state.userSubscriptionIndex, Map.phash, caller) else return [];
+    let ?subs = BTree.get(state.userSubscriptionIndex2, Principal.compare, caller) else return [];
     debug logDebug(debug_channel.announce, "Subs: get_user_payments index " # debug_show(subs));
 
     let results = Buffer.Buffer<Service.PaymentRecord>(1);
 
-    label subaccounts for(subaccountRecord in Map.entries(subs)){
+    label subaccounts for(subaccountRecord in BTree.entries(subs)){
       debug logDebug(debug_channel.announce, "Subs: get_user_payments subaccount" # debug_show((subaccountRecord), passesSubAccountFilter(filter, subaccountRecord.0)));
       if(passesSubAccountFilter(filter, subaccountRecord.0) == false) continue subaccounts;
-      label services for(thisService in Map.entries(subaccountRecord.1)){
+      label services for(thisService in BTree.entries(subaccountRecord.1)){
         debug logDebug(debug_channel.announce, "Subs: get_user_payments service" # debug_show(thisService));
         if(passesServiceFilter(filter, thisService.0) == false) continue services;
-        label productSubs for(thisProductSub in Map.entries(thisService.1)){
+        label productSubs for(thisProductSub in BTree.entries(thisService.1)){
           if(passesProductFilter(filter, thisProductSub.0) == false) continue productSubs;
-          label products for(thisProduct in Set.keys(thisProductSub.1)){
+          label products for(thisProduct in BTree.entries(thisProductSub.1)){
             debug logDebug(debug_channel.announce, "Subs: get_user_payments product" # debug_show(thisProduct));
             
 
-            if(passesSubscriptionFilter(filter, thisProduct) == false) continue products;
+            if(passesSubscriptionFilter(filter, thisProduct.0) == false) continue products;
             
-            let ?subscription = Map.get(state.subscriptions, Map.nhash, thisProduct) else {
+            let ?subscription = BTree.get(state.subscriptions2, Nat.compare, thisProduct.0) else {
                 debug logDebug(debug_channel.announce, "Subs: get_user_payments payment not found" # debug_show(thisProduct));
                 continue products;
             };
@@ -1688,20 +1691,11 @@ module {
           
             label payments for(payment in Vector.vals(subscription.history)){
               debug logDebug(debug_channel.announce, "Subs: get_user_payments payment" # debug_show(payment));
-              let ?paymentRecord = Map.get(state.payments, Map.nhash, payment) else {
+              let ?paymentRecord = BTree.get(state.payments2, Nat.compare, payment) else {
                 debug logDebug(debug_channel.announce, "Subs: get_user_payments payment not found" # debug_show(payment));
                 continue products;
               };
-
-              if(bFound == false){
-                if(paymentRecord.paymentId == target){
-                  bFound := true;
-                } else {
-                  continue payments;
-                };
-              };
-              
-              results.add({
+              let thisRecord = {
                 paymentId = paymentRecord.paymentId;
                 fee = paymentRecord.fee;
                 amount = paymentRecord.amount;
@@ -1711,10 +1705,25 @@ module {
                 rate = paymentRecord.rate;
                 subscriptionId = paymentRecord.subscriptionId;
                 result = paymentRecord.result;
+                account = paymentRecord.account;
+                targetAccount = paymentRecord.targetAccount;
+                service = paymentRecord.service;
+                productId = paymentRecord.productId;
                 transactionId = paymentRecord.transactionId;
                 ledgerTransactionId = paymentRecord.ledgerTransactionId;
                 feeTransactionId = paymentRecord.feeTransactionId;
-              });
+              };
+
+              if(bFound == false){
+                if(userPaymentRecordCompare(target, thisRecord) == #less){
+                  bFound := true;
+                  //continue payments;
+                } else {
+                  continue payments;
+                };
+              };
+              
+              results.add(thisRecord);
 
               switch(take){
                 case(null) {};
@@ -1748,7 +1757,7 @@ module {
     label subs for(sub in subscriptionIds.vals()){
       
           
-      let ?subscription = Map.get(state.subscriptions, Map.nhash, sub) else {
+      let ?subscription = BTree.get(state.subscriptions2, Nat.compare, sub) else {
           debug logDebug(debug_channel.announce, "Subs: get_user_payments payment not found" # debug_show(sub));
           results.add(null);
           continue subs;
@@ -1777,9 +1786,9 @@ module {
     Buffer.toArray(results);
   };
 
-  public func get_sevice_payments(caller: Principal, filter: ?Service.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : [Service.PaymentRecord] {
+  public func get_service_payments(caller: Principal, filter: ?Service.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : [Service.PaymentRecord] {
     // Implementation of get user payments logic
-    debug logDebug(debug_channel.announce, "Subs: get_sevice_payments" # debug_show((caller, filter, prev, take)));
+    debug logDebug(debug_channel.announce, "Subs: get_service_payments" # debug_show((caller, filter, prev, take)));
 
     var bFound = switch(prev){
       case(null) true;
@@ -1787,29 +1796,80 @@ module {
     };
 
     let target = switch(prev){
-      case(null) 0;
-      case(?val) val;
+      case(null) minPayment;
+      case(?val){
+    
+        switch( BTree.get<Nat, PaymentRecord>(state.payments2, Nat.compare, val)){
+          case(null){
+            //find the closest item if any less than the id...incase it was deleted
+            let items = BTree.scanLimit(state.payments2, Nat.compare, 0, val, #bwd, 1).results;
+            if(items.size() > 0){
+              let val = items[0].1;
+              {
+                paymentId = val.paymentId;
+                date = val.date;
+                amount = val.amount;
+                fee = val.fee;
+                brokerFee = val.brokerFee;
+                brokerTransactionId = val.brokerTransactionId;
+                rate = val.rate;
+                ledgerTransactionId = val.ledgerTransactionId;
+                transactionId = val.transactionId;
+                feeTransactionId = val.feeTransactionId;
+                subscriptionId = val.subscriptionId;
+                productId = val.productId;
+                service = val.service;
+                targetAccount = val.targetAccount;
+                account = val.account;
+                result = val.result;
+              } : Service.PaymentRecord;
+            } else {
+              minPayment;
+            };
+          };
+          case(?val){
+            {
+              paymentId = val.paymentId;
+              date = val.date;
+              amount = val.amount;
+              fee = val.fee;
+              brokerFee = val.brokerFee;
+              brokerTransactionId = val.brokerTransactionId;
+              rate = val.rate;
+              ledgerTransactionId = val.ledgerTransactionId;
+              transactionId = val.transactionId;
+              feeTransactionId = val.feeTransactionId;
+              subscriptionId = val.subscriptionId;
+              productId = val.productId;
+              service = val.service;
+              targetAccount = val.targetAccount;
+              account = val.account;
+              result = val.result;
+            } : Service.PaymentRecord;
+          };
+        };
+      };
     };
 
-    let ?subs = Map.get(state.serviceSubscriptionIndex, Map.phash, caller) else return [];
+    let ?subs = BTree.get(state.serviceSubscriptionIndex2, Principal.compare, caller) else return [];
 
-    debug logDebug(debug_channel.announce, "Subs: get_sevice_payments index " # debug_show(subs));
+    debug logDebug(debug_channel.announce, "Subs: get_service_payments index " # debug_show(subs));
 
     let results = Buffer.Buffer<Service.PaymentRecord>(1);
 
     
-    label productSubs for(thisProductSub in Map.entries(subs)){
+    label productSubs for(thisProductSub in BTree.entries(subs)){
       if(passesServiceProductFilter(filter, thisProductSub.0) == false) continue productSubs;
-      label products for(thisProduct in Set.keys(thisProductSub.1)){
-        debug logDebug(debug_channel.announce, "Subs: get_sevice_payments product" # debug_show(thisProduct));
+      label products for(thisProduct in BTree.entries(thisProductSub.1)){
+        debug logDebug(debug_channel.announce, "Subs: get_service_payments product" # debug_show(thisProduct));
         
-        if(passesServiceSubscriptionFilter(filter, thisProduct) == false) continue products;
+        if(passesServiceSubscriptionFilter(filter, thisProduct.0) == false) continue products;
         
-        let ?subscription = Map.get(state.subscriptions, Map.nhash, thisProduct) else {
-            debug logDebug(debug_channel.announce, "Subs: get_sevice_payments payment not found" # debug_show(thisProduct));
+        let ?subscription = BTree.get(state.subscriptions2, Nat.compare, thisProduct.0) else {
+            debug logDebug(debug_channel.announce, "Subs: get_service_payments payment not found" # debug_show(thisProduct));
             continue products;
         };
-        debug logDebug(debug_channel.announce, "Subs: get_sevice_payments subscription" # debug_show((subscription, Vector.toArray(subscription.history))));
+        debug logDebug(debug_channel.announce, "Subs: get_service_payments subscription" # debug_show((subscription, Vector.toArray(subscription.history))));
 
         switch(filter){
           case(null) {};
@@ -1852,24 +1912,14 @@ module {
           };
         };
 
-        for(thisPayment in Vector.vals(subscription.history)){
+        label paymentLoop for(thisPayment in Vector.vals(subscription.history)){
 
-          if(bFound == false){
-            if(thisPayment == target){
-              bFound := true;
-            } else {
-              continue products;
-            };
-          };
-
-          
-
-          let ?paymentRecord = Map.get(state.payments, Map.nhash, thisPayment) else {
-            debug logDebug(debug_channel.announce, "Subs: get_sevice_payments payment not found" # debug_show(thisProduct));
+          let ?paymentRecord = BTree.get(state.payments2, Nat.compare, thisPayment) else {
+            debug logDebug(debug_channel.announce, "Subs: get_service_payments payment not found" # debug_show(thisProduct));
             continue products;
           };
 
-          results.add({
+          let thisRecord = {
             paymentId = paymentRecord.paymentId;
             fee = paymentRecord.fee;
             amount = paymentRecord.amount;
@@ -1877,12 +1927,28 @@ module {
             brokerFee = paymentRecord.brokerFee;
             brokerTransactionId = paymentRecord.brokerTransactionId;
             rate = paymentRecord.rate;
+            targetAccount = paymentRecord.targetAccount;
+            account = paymentRecord.account;
+            service = paymentRecord.service;
+            productId = paymentRecord.productId;
             subscriptionId = paymentRecord.subscriptionId;
             result = paymentRecord.result;
             transactionId = paymentRecord.transactionId;
             ledgerTransactionId = paymentRecord.ledgerTransactionId;
             feeTransactionId = paymentRecord.feeTransactionId;
-          });
+          };
+
+          if(bFound == false){
+            logDebug(debug_channel.announce, "Subs: get_service_payments comparing" # debug_show((target, thisRecord, servicePaymentRecordCompare(target, thisRecord))));
+            if(servicePaymentRecordCompare(target, thisRecord) == #less){
+              bFound := true;
+              //continue products;
+            } else {
+              continue paymentLoop;
+            };
+          };
+
+          results.add(thisRecord);
 
           switch(take){
             case(null) {};
@@ -1900,6 +1966,24 @@ module {
     Buffer.toArray(results);
   };
 
+  let minSub = {
+    account = {owner = Principal.fromText("aaaaaa-aa"); subaccount = null};
+    amountPerInterval = 0;
+    baseRateAsset = null;
+    endDate = null;
+    interval = #Daily;
+    nextPayment = null;
+    nextPaymentAmount = null;
+    productId = null;
+    serviceCanister = Principal.fromText("aaaaaa-aa");
+    status = #Active;
+    subscriptionId = 0;
+    tokenCanister = Principal.fromText("aaaaaa-aa");
+    tokenPointer = null;
+    brokerId = null;
+    targetAccount = null;
+  };
+
 public func get_user_subscriptions(caller: Principal, filter: ?UserSubscriptionsFilter, prev: ?Nat, take: ?Nat) : [Service.Subscription] {
     // Implementation of get user payments logic
     debug logDebug(debug_channel.announce, "Subs: get_user_subscriptions" # debug_show((caller, filter, prev, take)));
@@ -1909,42 +1993,81 @@ public func get_user_subscriptions(caller: Principal, filter: ?UserSubscriptions
       case(?val) false;
     };
 
-    let target = switch(prev){
-      case(null) 0;
-      case(?val) val;
+    let target : Service.Subscription = switch(prev){
+      case(null) minSub;
+      case(?val){
+        switch( BTree.get<Nat, SubscriptionState>(state.subscriptions2, Nat.compare, val)){
+              case(null){
+                //find the closest item if any less than the id...incase it was deleted
+                let items = BTree.scanLimit(state.subscriptions2, Nat.compare, 0, val, #bwd, 1).results;
+                if(items.size() > 0){
+                  let val = items[0].1;
+                  {
+                    subscriptionId = val.subscriptionId;
+                    account = val.account;
+                    amountPerInterval = val.amountPerInterval;
+                    baseRateAsset = val.baseRateAsset;
+                    brokerId = val.brokerId;
+                    endDate = val.endDate;
+                    interval = val.interval;
+                    productId = val.productId;
+                    serviceCanister = val.serviceCanister;
+                    status = val.status;
+                    targetAccount = val.targetAccount;
+                    tokenCanister = val.tokenCanister;
+                    tokenPointer = val.tokenPointer;
+                  } : Service.Subscription;
+                  
+                } else {
+                  minSub;
+                };
+              };
+              case(?val){
+                {
+                  subscriptionId = val.subscriptionId;
+                  account = val.account;
+                  amountPerInterval = val.amountPerInterval;
+                  baseRateAsset = val.baseRateAsset;
+                  brokerId = val.brokerId;
+                  endDate = val.endDate;
+                  interval = val.interval;
+                  productId = val.productId;
+                  serviceCanister = val.serviceCanister;
+                  status = val.status;
+                  targetAccount = val.targetAccount;
+                  tokenCanister = val.tokenCanister;
+                  tokenPointer = val.tokenPointer;
+                } : Service.Subscription;
+              };
+            };
+      };
     };
 
-    let ?subs = Map.get(state.userSubscriptionIndex, Map.phash, caller) else return [];
+    let ?subs = BTree.get(state.userSubscriptionIndex2, Principal.compare, caller) else return [];
     debug logDebug(debug_channel.announce, "Subs: get_user_subscriptions index " # debug_show(subs));
 
     let results = Buffer.Buffer<Service.Subscription>(1);
 
-    label subaccounts for(subaccountRecord in Map.entries(subs)){
+    label subaccounts for(subaccountRecord in BTree.entries(subs)){
       debug logDebug(debug_channel.announce, "Subs: get_user_subscriptions subaccount" # debug_show((subaccountRecord), passesSubAccountFilter(filter, subaccountRecord.0)));
       if(passesSubAccountFilter(filter, subaccountRecord.0) == false) continue subaccounts;
-      label services for(thisService in Map.entries(subaccountRecord.1)){
+      label services for(thisService in BTree.entries(subaccountRecord.1)){
         debug logDebug(debug_channel.announce, "Subs: get_user_subscriptions service" # debug_show(thisService));
         if(passesServiceFilter(filter, thisService.0) == false) continue services;
-        label productSubs for(thisProductSubs in Map.entries(thisService.1)){
+        label productSubs for(thisProductSubs in BTree.entries(thisService.1)){
           if(passesProductFilter(filter, thisProductSubs.0) == false) continue productSubs;
-          label products for(thisProduct in Set.keys(thisProductSubs.1)){
+          label products for(thisProduct in BTree.entries(thisProductSubs.1)){
             debug logDebug(debug_channel.announce, "Subs: get_user_subscriptions product" # debug_show(thisProduct));
             
 
-            if(passesSubscriptionFilter(filter, thisProduct) == false) continue products;
+            if(passesSubscriptionFilter(filter, thisProduct.0) == false) continue products;
             
-            let ?subscription = Map.get(state.subscriptions, Map.nhash, thisProduct) else {
+            let ?subscription = BTree.get(state.subscriptions2, Nat.compare, thisProduct.0) else {
                 debug logDebug(debug_channel.announce, "Subs: get_user_subscriptions payment not found" # debug_show(thisProduct));
                 continue products;
             };
 
-            if(bFound == false){
-              if(subscription.subscriptionId == target){
-                bFound := true;
-              } else {
-                continue products;
-              };
-            };
+            
 
             switch(filter){
               case(null) {};
@@ -1986,8 +2109,19 @@ public func get_user_subscriptions(caller: Principal, filter: ?UserSubscriptions
                 };
               };
             };
+
+            let thisSubscription = shareSubscriptionState(subscription);
+
+            if(bFound == false){
+              if(userSubscriptionCompare(target,thisSubscription) == #less){  
+                bFound := true;
+                //continue products;
+              } else {
+                continue products;
+              };
+            };
             
-            results.add(shareSubscriptionState(subscription));
+            results.add(thisSubscription);
 
             switch(take){
               case(null) {};
@@ -2006,52 +2140,91 @@ public func get_user_subscriptions(caller: Principal, filter: ?UserSubscriptions
     Buffer.toArray(results);
   };
 
-  public func get_sevice_subscriptions(caller: Principal, filter: ?Service.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : [Service.Subscription] {
+  public func get_service_subscriptions(caller: Principal, filter: ?Service.ServiceSubscriptionFilter, prev: ?Nat, take: ?Nat) : [Service.Subscription] {
       // Implementation of get user payments logic
-      debug logDebug(debug_channel.announce, "Subs: get_sevice_subscriptions" # debug_show((caller, filter, prev, take)));
+      debug logDebug(debug_channel.announce, "Subs: get_service_subscriptions" # debug_show((caller, filter, prev, take)));
 
       var bFound = switch(prev){
         case(null) true;
         case(?val) false;
       };
 
-      let target = switch(prev){
-        case(null) 0;
-        case(?val) val;
+      let target : Service.Subscription = switch(prev){
+      case(null) minSub;
+      case(?val){
+        switch( BTree.get<Nat, SubscriptionState>(state.subscriptions2, Nat.compare, val)){
+          case(null){
+            //find the closest item if any less than the id...incase it was deleted
+            let items = BTree.scanLimit(state.subscriptions2, Nat.compare, 0, val, #bwd, 1).results;
+            if(items.size() > 0){
+              let val = items[0].1;
+              {
+                subscriptionId = val.subscriptionId;
+                account = val.account;
+                amountPerInterval = val.amountPerInterval;
+                baseRateAsset = val.baseRateAsset;
+                brokerId = val.brokerId;
+                endDate = val.endDate;
+                interval = val.interval;
+                productId = val.productId;
+                serviceCanister = val.serviceCanister;
+                status = val.status;
+                targetAccount = val.targetAccount;
+                tokenCanister = val.tokenCanister;
+                tokenPointer = val.tokenPointer;
+              } : Service.Subscription;
+              
+            } else {
+              minSub;
+            };
+          };
+          case(?val){
+            {
+              subscriptionId = val.subscriptionId;
+              account = val.account;
+              amountPerInterval = val.amountPerInterval;
+              baseRateAsset = val.baseRateAsset;
+              brokerId = val.brokerId;
+              endDate = val.endDate;
+              interval = val.interval;
+              productId = val.productId;
+              serviceCanister = val.serviceCanister;
+              status = val.status;
+              targetAccount = val.targetAccount;
+              tokenCanister = val.tokenCanister;
+              tokenPointer = val.tokenPointer;
+            } : Service.Subscription;
+          };
+        };
       };
+    };
 
-      let ?subs = Map.get(state.serviceSubscriptionIndex, Map.phash, caller) else return [];
+      let ?subs = BTree.get(state.serviceSubscriptionIndex2, Principal.compare, caller) else return [];
 
-      debug logDebug(debug_channel.announce, "Subs: get_sevice_subscriptions index " # debug_show(subs));
+      debug logDebug(debug_channel.announce, "Subs: get_service_subscriptions index " # debug_show(subs));
 
       let results = Buffer.Buffer<Service.Subscription>(1);
 
       
-      label productSubs for(thisProductSubs in Map.entries(subs)){
+      label productSubs for(thisProductSubs in BTree.entries(subs)){
         if(passesServiceProductFilter(filter, thisProductSubs.0) == false) continue productSubs;
-        label products for(thisProduct in Set.keys(thisProductSubs.1)){
-          debug logDebug(debug_channel.announce, "Subs: get_sevice_subscriptions product" # debug_show(thisProduct));
+        label products for(thisProduct in BTree.entries(thisProductSubs.1)){
+          debug logDebug(debug_channel.announce, "Subs: get_service_subscriptions product" # debug_show(thisProduct));
           
 
           
-          if(passesServiceSubscriptionFilter(filter, thisProduct) == false) continue products;
+          if(passesServiceSubscriptionFilter(filter, thisProduct.0) == false) continue products;
           
-          let ?subscription = Map.get(state.subscriptions, Map.nhash, thisProduct) else {
-              debug logDebug(debug_channel.announce, "Subs: get_sevice_subscriptions payment not found" # debug_show(thisProduct));
+          let ?subscription = BTree.get(state.subscriptions2, Nat.compare, thisProduct.0) else {
+              debug logDebug(debug_channel.announce, "Subs: get_service_subscriptions payment not found" # debug_show(thisProduct));
               continue products;
           };
 
 
 
-          debug logDebug(debug_channel.announce, "Subs: get_sevice_subscriptions subscription" # debug_show((subscription, Vector.toArray(subscription.history))));
+          debug logDebug(debug_channel.announce, "Subs: get_service_subscriptions subscription" # debug_show((subscription, Vector.toArray(subscription.history))));
 
-          if(bFound == false){
-            if(subscription.subscriptionId == target){
-              bFound := true;
-            } else {
-              continue products;
-            };
-          };
+          
 
           switch(filter){
             case(null) {};
@@ -2094,7 +2267,17 @@ public func get_user_subscriptions(caller: Principal, filter: ?UserSubscriptions
             };
           };
 
-          results.add(shareSubscriptionState(subscription));
+          let thisSubscription = shareSubscriptionState(subscription);
+
+          if(bFound == false){
+            if(serviceSubscriptionCompare(target,thisSubscription) == #less){
+              bFound := true;
+            } else {
+              continue products;
+            };
+          };
+
+          results.add(thisSubscription);
 
           switch(take){
             case(null) {};

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -1578,7 +1578,7 @@ module {
   };
 
   private let minPayment = {
-      account = {owner = Principal.fromText("aaaaaa-aa"); subaccount = null};
+      account = {owner = Principal.fromText("aaaaa-aa"); subaccount = null};
       amount = 0;
       date = 0;
       fee = ?0;
@@ -1588,7 +1588,7 @@ module {
       rate = null;
       subscriptionId = 0;
       result = #Ok;
-      service = Principal.fromText("aaaaaa-aa");
+      service = Principal.fromText("aaaaa-aa");
       productId = null;
       transactionId = ?0;
       ledgerTransactionId = ?0;
@@ -1967,7 +1967,7 @@ module {
   };
 
   let minSub = {
-    account = {owner = Principal.fromText("aaaaaa-aa"); subaccount = null};
+    account = {owner = Principal.fromText("aaaaa-aa"); subaccount = null};
     amountPerInterval = 0;
     baseRateAsset = null;
     endDate = null;
@@ -1975,10 +1975,10 @@ module {
     nextPayment = null;
     nextPaymentAmount = null;
     productId = null;
-    serviceCanister = Principal.fromText("aaaaaa-aa");
+    serviceCanister = Principal.fromText("aaaaa-aa");
     status = #Active;
     subscriptionId = 0;
-    tokenCanister = Principal.fromText("aaaaaa-aa");
+    tokenCanister = Principal.fromText("aaaaa-aa");
     tokenPointer = null;
     brokerId = null;
     targetAccount = null;

--- a/src/migrations/lib.mo
+++ b/src/migrations/lib.mo
@@ -3,10 +3,12 @@ import D "mo:base/Debug";
 import MigrationTypes "./types";
 import v0_0_0 "./v000_000_000";
 import v0_1_0 "./v000_001_000";
+import v0_2_0 "./v000_002_000";
 
 module {
   let upgrades = [
     v0_1_0.upgrade,
+    v0_2_0.upgrade,
     // do not forget to add your new migration upgrade method here
   ];
 
@@ -14,6 +16,7 @@ module {
     return switch (state) {
       case (#v0_0_0(_)) 0;
       case (#v0_1_0(_)) 1;
+      case (#v0_2_0(_)) 2;
       // do not forget to add your new migration id here
       // should be increased by 1 as it will be later used as an index to get upgrade/downgrade methods
     };

--- a/src/migrations/types.mo
+++ b/src/migrations/types.mo
@@ -1,23 +1,24 @@
 import v0_1_0 "./v000_001_000/types";
-import Int "mo:base/Int";
+import v0_2_0 "./v000_002_000/types";
 
 
 module {
   // do not forget to change current migration when you add a new one
   // you should use this field to import types from you current migration anywhere in your project
   // instead of importing it from migration folder itself
-  public let Current = v0_1_0;
+  public let Current = v0_2_0;
 
   public type Args = ?v0_1_0.InitArgs;
 
   //change this current migration when you add a new one
-  public let CurrentMigration = #v0_1_0;
+  public let CurrentMigration = #v0_2_0;
   
   public let InitialMigration = #v0_0_0;
 
   public type State = {
     #v0_0_0: {#id; #data};
     #v0_1_0: {#id; #data:  v0_1_0.State};
+    #v0_2_0: {#id; #data:  v0_2_0.State};
     // do not forget to add your new migration state types here
   };
 };

--- a/src/migrations/v000_001_000/lib.mo
+++ b/src/migrations/v000_001_000/lib.mo
@@ -159,7 +159,7 @@ module {
       };
     };
 
-    let state : MigrationTypes.Current.State = {
+    let state : v0_1_0.State = {
       userSubscriptionIndex = userIndex;
       serviceSubscriptionIndex = serviceIndex;
       subscriptions = existing_subs;

--- a/src/migrations/v000_002_000/lib.mo
+++ b/src/migrations/v000_002_000/lib.mo
@@ -1,0 +1,91 @@
+import D "mo:base/Debug";
+import Principal "mo:base/Principal";
+import Nat "mo:base/Nat";
+import Map "mo:map/Map";
+import BTree "mo:stableheapbtreemap/BTree";
+
+import MigrationTypes "../types";
+import v0_2_0 "types";
+
+module {
+
+
+  private func fileSubscription(state: v0_2_0.State, subscription: v0_2_0.SubscriptionState) : () {
+    let userProductMap = v0_2_0.findOrCreateUserProductMap(state, subscription);
+    let serviceProductMap = v0_2_0.findOrCreateServiceProductMap(state, subscription);
+    ignore v0_2_0.BTree.insert(userProductMap, Nat.compare, subscription.subscriptionId, true);
+    ignore v0_2_0.BTree.insert(serviceProductMap, Nat.compare, subscription.subscriptionId, true);
+  };
+
+  public func upgrade(prev_migration_state: MigrationTypes.State, args: MigrationTypes.Args, caller: Principal): MigrationTypes.State {
+
+    let oldState = switch (prev_migration_state) { case (#v0_1_0(#data(state))) state; case (_) D.trap("Unexpected migration state") };
+
+    let newState : MigrationTypes.Current.State = {
+      userSubscriptionIndex = oldState.userSubscriptionIndex;
+      userSubscriptionIndex2 = BTree.init<Principal, v0_2_0.SubAccountSubscriptionMap2>(null);
+      serviceSubscriptionIndex2 = BTree.init<Principal, v0_2_0.ProductSubscriptionMap2>(null);
+      serviceSubscriptionIndex = oldState.serviceSubscriptionIndex;
+      subscriptions = oldState.subscriptions;
+      subscriptions2 = BTree.init<Nat, v0_2_0.SubscriptionState>(null);
+      payments = oldState.payments;
+      payments2 = BTree.init<Nat, v0_2_0.PaymentRecord2>(null);
+      assetInfo = oldState.assetInfo;
+      tokenInfo = oldState.tokenInfo;
+      notifications = oldState.notifications;
+      recentTrx = oldState.recentTrx;
+      var nextNotificationId = oldState.nextNotificationId;
+      var publicGoodsAccount = oldState.publicGoodsAccount;
+      var nextSubscriptionId = oldState.nextSubscriptionId;
+      var nextPaymentId = oldState.nextPaymentId;
+      var exchangeRateCanister = oldState.exchangeRateCanister;
+      var feeBPS = oldState.feeBPS;
+      var maxTake = oldState.maxTake;
+      var maxUpdates = oldState.maxUpdates;
+      var maxQueries = oldState.maxQueries;
+      var defaultTake = oldState.defaultTake;
+      var trxWindow = oldState.trxWindow;
+      var minDrift = oldState.minDrift;
+      var maxMemoSize = oldState.maxMemoSize;
+    };
+
+    for(thisSub in Map.entries(oldState.subscriptions)){
+      ignore v0_2_0.BTree.insert(newState.subscriptions2, Nat.compare, thisSub.0, thisSub.1);
+    };
+
+    //rebuild payment records
+    for(thisPayment in Map.entries(oldState.payments)){
+      let ?sub = Map.get(oldState.subscriptions, Map.nhash, thisPayment.1.subscriptionId) else D.trap("Subscription not found");
+      let newPayment : v0_2_0.PaymentRecord2  = {
+        paymentId = thisPayment.0;
+        date = thisPayment.1.date;
+        amount = thisPayment.1.amount;
+        var fee = thisPayment.1.fee;
+        var brokerFee = thisPayment.1.brokerFee;
+        var brokerTransactionId = thisPayment.1.brokerTransactionId;
+        rate = thisPayment.1.rate;
+        var ledgerTransactionId = thisPayment.1.ledgerTransactionId;
+        var transactionId = thisPayment.1.transactionId;
+        var feeTransactionId = thisPayment.1.fee;
+        subscriptionId = thisPayment.1.subscriptionId;
+        productId = sub.productId;
+        service = sub.serviceCanister;
+        targetAccount = sub.targetAccount;
+        account = sub.account;
+        result = thisPayment.1.result;
+      };
+
+      ignore v0_2_0.BTree.insert(newState.payments2, Nat.compare, thisPayment.0, newPayment);
+    };
+
+
+    //rebuild user and service Index
+    for(thisItem in Map.entries(oldState.subscriptions)){
+      fileSubscription(newState, thisItem.1);
+    };
+    
+    //rebuild service Index
+    return #v0_2_0(#data(newState));
+  };
+
+};

--- a/src/migrations/v000_002_000/types.mo
+++ b/src/migrations/v000_002_000/types.mo
@@ -1,0 +1,505 @@
+// please do not import any types from your project outside migrations folder here
+// it can lead to bugs when you change those types later, because migration types should not be changed
+// you should also avoid importing these types anywhere in your project directly from here
+// use MigrationTypes.Current property instead
+
+import Blob "mo:base/Blob";
+import Bool "mo:base/Bool";
+import D "mo:base/Debug";
+import Nat "mo:base/Nat";
+import Order "mo:base/Order";
+import Principal "mo:base/Principal";
+import Text "mo:base/Text";
+
+import MapLib "mo:map/Map";
+import SetLib "mo:map/Set";
+import VecLib "mo:vector";
+import BTreeLib "mo:stableheapbtreemap/BTree";
+import BTree "mo:stableheapbtreemap/BTree";
+import TTLib "mo:timer-tool";
+import Service "../../Service";
+import v0_1_0 "../v000_001_000/types";
+/*
+
+import Star "mo:star/star";
+ */
+
+module {
+
+  let debug_channel = {
+    subscribe = true;
+  };
+
+  private func logDebug(bEmit: Bool, message: Text) {
+    if(bEmit) D.print(message);
+  };
+
+  public let Map = MapLib;
+  public let Set = SetLib;
+  public let Vector = VecLib;
+  public let BTree = BTreeLib;
+  public let TimerTool = TTLib;
+
+  public type Account = v0_1_0.Account;
+
+  public type Value = v0_1_0.Value;
+
+  public let isICRC80 = v0_1_0.isICRC80;
+
+  public type Interval =  v0_1_0.Interval;
+
+  public type Asset = v0_1_0.Asset;
+  public type AssetClass = v0_1_0.AssetClass;
+
+  public type SubStatus = v0_1_0.SubStatus;
+
+  public type TokenCanisterPointer = v0_1_0.TokenCanisterPointer;
+
+  public type SubscriptionState = v0_1_0.SubscriptionState;
+
+  public type CheckRate =  v0_1_0.CheckRate;
+
+  public type SubscriptionStateShared = v0_1_0.SubscriptionStateShared;
+
+  public let shareSubscriptionState = v0_1_0.shareSubscriptionState;
+
+  public type ProductSubscriptionMap = v0_1_0.ProductSubscriptionMap; 
+  public type ProductSubscriptionMap2 =  BTreeLib.BTree<?Nat, BTree.BTree<Nat, Bool>>;
+  
+  public type ServiceSubscriptionMap = v0_1_0.ServiceSubscriptionMap;
+  public type ServiceSubscriptionMap2 = BTreeLib.BTree<Principal, ProductSubscriptionMap2>;
+
+  public type SubAccountSubscriptionMap = v0_1_0.SubAccountSubscriptionMap;
+  public type SubAccountSubscriptionMap2 = BTreeLib.BTree<Blob, ServiceSubscriptionMap2>;
+
+  public type UserSubscriptionIndex = v0_1_0.UserSubscriptionIndex;
+  public type UserSubscriptionIndex2 = BTreeLib.BTree<Principal, SubAccountSubscriptionMap2>;
+
+  public type Subscription = {
+      subscriptionId: Nat;
+      tokenCanister: Principal;
+      tokenPointer: ?Blob;
+      serviceCanister: Principal;
+      interval: Interval;
+      productId: ?Nat;
+      amountPerInterval: Nat;
+      baseRateAsset: ?Asset;
+      brokerId: ?Account;
+      endDate: ?Nat; // Timestamp in nanoseconds to end the subscription
+      targetAccount: ?Account;
+      account: Account;
+      status: SubStatus;
+  };
+
+  public func subAccountCompare(a : ?Blob, b : ?Blob) : Order.Order {
+    switch(a, b){
+      case(null, null) return #equal;
+      case(?vala, ?valb){
+       Blob.compare(vala, valb);
+      };
+      case(null,?val){
+        Blob.compare(nullSubaccount, val);
+      };
+      case(?val,null){
+        Blob.compare(val, nullSubaccount);
+      };
+    };
+  };
+
+
+  public func userSubscriptionCompare(a : Service.Subscription, b : Service.Subscription) : Order.Order {
+    switch(Principal.compare(a.account.owner, b.account.owner)){
+      case(#equal) {
+         switch(subAccountCompare(a.account.subaccount, b.account.subaccount)){
+          case(#equal) {
+            switch(Principal.compare(a.serviceCanister, b.serviceCanister)){
+              case(#equal) {
+                switch(nullNcompare(a.productId, b.productId)){
+                  case(#equal) {
+                    Nat.compare(a.subscriptionId, b.subscriptionId);
+                  };
+                  case(#less) {
+                    return #less;
+                  };
+                  case(#greater) {
+                    return #greater;
+                  };
+                };
+              };
+              case(#less) {
+                return #less;
+              };
+              case(#greater) {
+                return #greater;
+              };
+            };
+          };
+          case(#less) {
+            return #less;
+          };
+          case(#greater) {
+            return #greater;
+          };
+         };
+      };
+      case(#less) {
+        return #less;
+      };
+      case(#greater) {
+        return #greater;
+      };
+    };
+  };
+
+  public func userPaymentRecordCompare(a : Service.PaymentRecord, b : Service.PaymentRecord) : Order.Order {
+    switch(Principal.compare(a.account.owner, b.account.owner)){
+      case(#equal) {
+         switch(subAccountCompare(a.account.subaccount, b.account.subaccount)){
+          case(#equal) {
+            switch(Principal.compare(a.service, b.service)){
+              case(#equal) {
+                switch(nullNcompare(a.productId, b.productId)){
+                  case(#equal) {
+                    switch(Nat.compare(a.subscriptionId, b.subscriptionId)){
+                      case(#equal) {
+                        return Nat.compare(a.paymentId, b.paymentId);
+                      };
+                      case(#less) {
+                        return #less;
+                      };
+                      case(#greater) {
+                        return #greater;
+                      };
+                    };
+                  };
+                  case(#less) {
+                    return #less;
+                  };
+                  case(#greater) {
+                    return #greater;
+                  };
+                };
+              };
+              case(#less) {
+                return #less;
+              };
+              case(#greater) {
+                return #greater;
+              };
+            };
+          };
+          case(#less) {
+            return #less;
+          };
+          case(#greater) {
+            return #greater;
+          };
+         };
+      };
+      case(#less) {
+        return #less;
+      };
+      case(#greater) {
+        return #greater;
+      };
+    };
+  };
+
+
+  public type GlobalSubscriptionMap = v0_1_0.GlobalSubscriptionMap;
+  public type GlobalSubscriptionMap2 =  BTree.BTree<Nat, SubscriptionState>;
+
+
+  public type ScheduledPaymentArgs = v0_1_0.ScheduledPaymentArgs;
+
+
+  ///MARK: Interceptors
+  public type CanAddSubscription = v0_1_0.CanAddSubscription;
+
+
+  public type TokenInfo = v0_1_0.TokenInfo;
+
+  public type KnownTokenMap = v0_1_0.KnownTokenMap;
+
+  public type KnownAssetMap = v0_1_0.KnownAssetMap;
+
+  
+
+  public type ServiceNotificationType = v0_1_0.ServiceNotificationType;
+
+  
+  public type ExchangeRate = v0_1_0.ExchangeRate;
+
+  public type ExchangeRateError = v0_1_0.ExchangeRateError;
+  public type ExchangeRateMetadata = v0_1_0.ExchangeRateMetadata;
+
+  public type ServiceNotification = v0_1_0.ServiceNotification;
+
+  
+
+  
+
+  /// `Stats`
+  ///
+  /// Represents collected statistics about the ledger, such as the total number of accounts.
+  public type Stats = v0_1_0.Stats;
+
+  public let subAccountEqual = v0_1_0.subAccountEqual;
+
+  public let knownTokenHash32 = v0_1_0.knownTokenHash32;
+
+  public let knownTokenEq = v0_1_0.knownTokenEq;
+
+    public let knownTokenCompare = v0_1_0.knownTokenCompare;
+
+  public let ktHash = (v0_1_0.knownTokenHash32, v0_1_0.knownTokenEq);
+
+  public let assetHash32 = v0_1_0.assetHash32;
+
+  public let assetEq = v0_1_0.assetEq;
+
+    public let assetCompare = v0_1_0.assetCompare;
+
+  public let assetHash = (v0_1_0.assetHash32, v0_1_0.assetEq);
+
+  public let nullNHash32 = v0_1_0.nullNHash32;
+
+  public let nullNeq = v0_1_0.nullNeq;
+
+  public let nullNcompare = v0_1_0.nullNcompare;
+
+  public let nullNHash = v0_1_0.nullNHash;
+  public let accountHash32 = v0_1_0.accountHash32;
+
+  public let nullSubaccount = v0_1_0.nullSubaccount;
+
+  public let accountEq = v0_1_0.accountEq;
+
+  public let accountCompare = v0_1_0.accountCompare;
+
+  public let ahash = (v0_1_0.accountHash32, v0_1_0.accountEq);
+
+  public type PaymentRecord = v0_1_0.PaymentRecord;
+
+  public type PaymentRecord2 = {
+    paymentId: Nat;
+    date: Nat; // Timestamp of the payment
+    amount: Nat;
+    var fee: ?Nat;
+    var brokerFee: ?Nat;
+    var brokerTransactionId: ?Nat;
+    rate: ?ExchangeRate; // if used
+    var ledgerTransactionId: ?Nat;
+    var transactionId: ?Nat;
+    var feeTransactionId: ?Nat;
+    subscriptionId: Nat;
+    productId: ?Nat;
+    service: Principal;
+    targetAccount: ?Account;
+    account: Account;
+    result: {
+      #Ok;
+      #Err: {
+        code: Nat;
+        message: Text;
+      };
+    };
+  };
+
+  public func servicePaymentRecordCompare(a : Service.PaymentRecord, b : Service.PaymentRecord) : Order.Order {
+    switch(Principal.compare(a.service, b.service)){
+      case(#equal) {
+        switch(nullNcompare(a.productId, b.productId)){
+          case(#equal) {
+      
+            switch(Nat.compare(a.subscriptionId, b.subscriptionId)){
+              case(#equal) {
+                Nat.compare(a.paymentId, b.paymentId);
+              };
+              case(#less) {
+                return #less;
+              };
+              case(#greater) {
+                return #greater;
+              };
+            };
+              
+          };
+          case(#less) {
+            return #less;
+          };
+          case(#greater) {
+            return #greater;
+          };
+        };
+      };
+      case(#less) {
+        return #less;
+      };
+      case(#greater){
+        return #greater;
+      };
+    };
+  };
+
+  public func serviceSubscriptionCompare(a : Service.Subscription, b : Service.Subscription) : Order.Order {
+    switch(Principal.compare(a.serviceCanister, b.serviceCanister)){
+      case(#equal) {
+        switch(nullNcompare(a.productId, b.productId)){
+          case(#equal) {
+            Nat.compare(a.subscriptionId, b.subscriptionId);
+          };
+          case(#less) {
+            return #less;
+          };
+          case(#greater) {
+            return #greater;
+          };
+        };
+      };
+      case(#less) {
+        return #less;
+      };
+      case(#greater){
+        return #greater;
+      };
+    };
+  };
+
+  public func subaccountToBlob(aBlob : ?Blob) : Blob {
+      switch(aBlob){
+        case(null) nullSubaccount;
+        case(?val) val;
+      };
+    };
+
+  public func findOrCreateUserProductMap(state: State, subscription: SubscriptionState) : BTree.BTree<Nat, Bool> {
+
+    debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap" # debug_show(subscription));
+    
+    let accountMap : SubAccountSubscriptionMap2 = switch(BTree.get(state.userSubscriptionIndex2, Principal.compare, subscription.account.owner)){
+      case(null) {
+
+        debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap accountMap null" # debug_show(subscription.account.owner));
+        let accountMap = BTree.init<Blob, ServiceSubscriptionMap2>(null);
+        ignore BTree.insert<Principal, SubAccountSubscriptionMap2>(state.userSubscriptionIndex2, Principal.compare, subscription.account.owner, accountMap);
+        accountMap;
+      };
+      case(?val) val;
+    };
+
+    let subBlob = subaccountToBlob(subscription.account.subaccount);
+
+    let serviceMap : ServiceSubscriptionMap2 = switch(BTree.get(accountMap, Blob.compare, subBlob)){
+      case(null) {
+        debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap serviceMap null" # debug_show(subscription.account.subaccount));
+        let serviceMap = BTree.init<Principal, ProductSubscriptionMap2>(null);
+        ignore BTree.insert<Blob, ServiceSubscriptionMap2>(accountMap, Blob.compare, subBlob, serviceMap);
+        serviceMap;
+      };
+      case(?val) val;
+    };
+
+    let productSubMap = switch(BTree.get(serviceMap, Principal.compare, subscription.serviceCanister)){
+      case(null) {
+        debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap productMap null" # debug_show(subscription.serviceCanister));
+        let productSubMap = BTree.init<?Nat, BTree.BTree<Nat, Bool>>(null);
+        ignore BTree.insert(serviceMap, Principal.compare, subscription.serviceCanister, productSubMap);
+        productSubMap;
+      };
+      case(?val) val;
+    };
+
+    let productMap = switch(BTree.get(productSubMap, nullNcompare, subscription.productId)){
+      case(null) {
+        debug logDebug(debug_channel.subscribe, "Subs: findOrCreateUserProductMap productMap null" # debug_show(subscription.productId));
+        let productMap = BTree.init<Nat, Bool>(null);
+        ignore BTree.insert(productSubMap, nullNcompare, subscription.productId, productMap);
+        productMap;
+      };
+      case(?val) val;
+    };
+
+    productMap;
+  };
+
+  public func findOrCreateServiceProductMap(state: State, subscription: SubscriptionState) : BTree.BTree<Nat,Bool> {
+
+    debug logDebug(debug_channel.subscribe, "Subs: findOrCreateServiceProductMap" # debug_show(subscription));
+    let productSubMap = switch(BTree.get(state.serviceSubscriptionIndex2, Principal.compare, subscription.serviceCanister)){
+      case(null) {
+        debug logDebug(debug_channel.subscribe, "Subs: findOrCreateServiceProductMap productMap null" # debug_show(subscription.serviceCanister));
+        let productSubMap = BTree.init<?Nat, BTree.BTree<Nat, Bool>>(null);
+        ignore BTree.insert(state.serviceSubscriptionIndex2, Principal.compare, subscription.serviceCanister, productSubMap);
+        productSubMap;
+      };
+      case(?val) val;
+    };
+
+    let productMap = switch(BTree.get(productSubMap, nullNcompare, subscription.productId)){
+      case(null) {
+        debug logDebug(debug_channel.subscribe, "Subs: findOrCreateServiceProductMap productMap null" # debug_show(subscription.productId));
+        let productMap = BTree.init<Nat,Bool>(null);
+        ignore BTree.insert(productSubMap, nullNcompare, subscription.productId, productMap);
+        productMap;
+      };
+      case(?val) val;
+    };
+    productMap;
+  };
+
+  ///MARK: Listeners
+
+  public type NewSubscriptionListener = v0_1_0.NewSubscriptionListener;
+  public type ActivateSubscriptionListener = v0_1_0.ActivateSubscriptionListener;
+  public type PauseSubscriptionListener = v0_1_0.PauseSubscriptionListener;
+  public type CanceledSubscriptionListener = v0_1_0.CanceledSubscriptionListener;
+  public type NewPaymentListener = v0_1_0.NewPaymentListener;
+
+  ///MARK: InitArgs
+
+
+  public type InitArgs =  v0_1_0.InitArgs;
+
+  public type FeeDetail = v0_1_0.FeeDetail;
+
+  ///MARK: environment
+
+  /// `Environment`
+  ///
+  /// A record that encapsulates various external dependencies and settings that the ledger relies on
+  /// for fee calculations, timestamp retrieval, and inter-canister communication.
+  /// can_transfer supports evaluating the transfer from both sync and async function.
+  public type Environment = v0_1_0.Environment;
+
+  ///MARK: state
+
+  public type State = {
+    payments: Map.Map<Nat, v0_1_0.PaymentRecord>;
+    payments2: BTreeLib.BTree<Nat, PaymentRecord2>;
+    userSubscriptionIndex : UserSubscriptionIndex;
+    userSubscriptionIndex2 : UserSubscriptionIndex2;
+    serviceSubscriptionIndex : ServiceSubscriptionMap;
+    serviceSubscriptionIndex2 : ServiceSubscriptionMap2;
+    subscriptions: GlobalSubscriptionMap;
+    subscriptions2: GlobalSubscriptionMap2;
+    tokenInfo: KnownTokenMap;
+    assetInfo: KnownAssetMap;
+    notifications: Map.Map<Principal, Map.Map<Nat, Service.ServiceNotification>>;
+    recentTrx: Map.Map<Blob, Nat>;
+    var publicGoodsAccount: Account;
+    var nextSubscriptionId: Nat;
+    var nextPaymentId: Nat;
+    var nextNotificationId: Nat;
+    var exchangeRateCanister: Principal;
+    var feeBPS: Nat; //basis points.
+    var maxTake: Nat;
+    var maxUpdates: Nat;
+    var maxQueries: Nat;
+    var minDrift: Nat;
+    var trxWindow: Nat;
+    var defaultTake: Nat;
+    var maxMemoSize: Nat;
+  };
+
+};

--- a/src/serializer.mo
+++ b/src/serializer.mo
@@ -124,7 +124,7 @@ module {
       };
        switch(item.productId){
         case(null){};
-        case(?val) items.add( ("prductId",#Nat(val)));
+        case(?val) items.add( ("productId",#Nat(val)));
       };
       switch(item.targetAccount){
         case(null){};


### PR DESCRIPTION
## v0_2_0 - 2024-09-24

### Fixed

- Converted Indexes to use BTree to force deterministic ordering.  Lookup occurs in index for every query with a prev argument. The query selects the next minimum payment or subscription by ID if the specified item has been deleted
- The label for the productId field has been fixed for the 79subCreate block.

### Updates

- productId, account, targetAccount, and service added to the Service.Product type as a convenience field as it reduces a call to get subscription to retrieve those values.